### PR TITLE
Fix element tagging

### DIFF
--- a/__tests__/setups/v3-stats/package-lock.json
+++ b/__tests__/setups/v3-stats/package-lock.json
@@ -1,0 +1,7684 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.0.0-beta.40",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz",
+			"integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
+			"requires": {
+				"@babel/highlight": "7.0.0-beta.40"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0-beta.40",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.40.tgz",
+			"integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
+			"requires": {
+				"chalk": "2.3.2",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"abab": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+		},
+		"acorn": {
+			"version": "5.5.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.1.tgz",
+			"integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ=="
+		},
+		"acorn-dynamic-import": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+			"integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
+			"requires": {
+				"acorn": "4.0.13"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "4.0.13",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+				}
+			}
+		},
+		"acorn-globals": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+			"requires": {
+				"acorn": "5.5.1"
+			}
+		},
+		"ajv": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"requires": {
+				"co": "4.6.0",
+				"fast-deep-equal": "1.1.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
+			}
+		},
+		"ajv-keywords": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+			"integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74="
+		},
+		"align-text": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+			"requires": {
+				"kind-of": "3.2.2",
+				"longest": "1.0.1",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"alphanum-sort": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+			"integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
+		},
+		"amdefine": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+		},
+		"ansi-escapes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+		},
+		"ansi-styles": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+		},
+		"anymatch": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"requires": {
+				"micromatch": "2.3.11",
+				"normalize-path": "2.1.1"
+			}
+		},
+		"append-transform": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+			"requires": {
+				"default-require-extensions": "1.0.0"
+			}
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"requires": {
+				"sprintf-js": "1.0.3"
+			}
+		},
+		"arr-diff": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"requires": {
+				"arr-flatten": "1.1.0"
+			}
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+		},
+		"array-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+		},
+		"array-unique": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+		},
+		"asn1": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+		},
+		"asn1.js": {
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+			"requires": {
+				"bn.js": "4.11.8",
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0"
+			}
+		},
+		"assert": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+			"requires": {
+				"util": "0.10.3"
+			}
+		},
+		"assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+		},
+		"assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+		},
+		"astral-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+		},
+		"async": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
+		"async-each": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+		},
+		"async-limiter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
+		"atob": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
+			"integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10="
+		},
+		"autoprefixer": {
+			"version": "6.7.7",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+			"integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+			"requires": {
+				"browserslist": "1.7.7",
+				"caniuse-db": "1.0.30000813",
+				"normalize-range": "0.1.2",
+				"num2fraction": "1.2.2",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+		},
+		"aws4": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"requires": {
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
+			}
+		},
+		"babel-core": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"requires": {
+				"babel-code-frame": "6.26.0",
+				"babel-generator": "6.26.1",
+				"babel-helpers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"convert-source-map": "1.5.1",
+				"debug": "2.6.9",
+				"json5": "0.5.1",
+				"lodash": "4.17.5",
+				"minimatch": "3.0.4",
+				"path-is-absolute": "1.0.1",
+				"private": "0.1.8",
+				"slash": "1.0.0",
+				"source-map": "0.5.7"
+			}
+		},
+		"babel-generator": {
+			"version": "6.26.1",
+			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"requires": {
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"detect-indent": "4.0.0",
+				"jsesc": "1.3.0",
+				"lodash": "4.17.5",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+				}
+			}
+		},
+		"babel-helpers": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
+			}
+		},
+		"babel-jest": {
+			"version": "22.4.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.1.tgz",
+			"integrity": "sha512-rEdN/jevSuX0IQKcUqwqOGa0gDNis4jGY52Rq53aizfDGPwQYNJq+f9NCMT1HUhtUZhYSjvfGUfHQWBRT1/icA==",
+			"requires": {
+				"babel-plugin-istanbul": "4.1.5",
+				"babel-preset-jest": "22.4.1"
+			}
+		},
+		"babel-loader": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.4.tgz",
+			"integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
+			"requires": {
+				"find-cache-dir": "1.0.0",
+				"loader-utils": "1.1.0",
+				"mkdirp": "0.5.1"
+			}
+		},
+		"babel-messages": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-istanbul": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz",
+			"integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
+			"requires": {
+				"find-up": "2.1.0",
+				"istanbul-lib-instrument": "1.9.2",
+				"test-exclude": "4.2.0"
+			}
+		},
+		"babel-plugin-jest-hoist": {
+			"version": "22.4.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.1.tgz",
+			"integrity": "sha512-gmj5FvFflXSnRapWmF/jDjx5Lof1kX0OwXibCxMOx38V3CFMOnTxLTUrAFfLkhCey3FJvv0ACvv/+h4nzFRxhg=="
+		},
+		"babel-plugin-syntax-object-rest-spread": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+		},
+		"babel-preset-jest": {
+			"version": "22.4.1",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.1.tgz",
+			"integrity": "sha512-gW3+spyB8fkSAI9fX+41BQMwar5LjR+nyKa2QRvK22snxnI29+jJVAMfId+osucFJzJJvhlvzKWnfwX8Omodvg==",
+			"requires": {
+				"babel-plugin-jest-hoist": "22.4.1",
+				"babel-plugin-syntax-object-rest-spread": "6.13.0"
+			}
+		},
+		"babel-register": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+			"requires": {
+				"babel-core": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.3",
+				"home-or-tmp": "2.0.0",
+				"lodash": "4.17.5",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.4.18"
+			},
+			"dependencies": {
+				"source-map-support": {
+					"version": "0.4.18",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+					"requires": {
+						"source-map": "0.5.7"
+					}
+				}
+			}
+		},
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"requires": {
+				"core-js": "2.5.3",
+				"regenerator-runtime": "0.11.1"
+			}
+		},
+		"babel-template": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"lodash": "4.17.5"
+			}
+		},
+		"babel-traverse": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"requires": {
+				"babel-code-frame": "6.26.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"debug": "2.6.9",
+				"globals": "9.18.0",
+				"invariant": "2.2.3",
+				"lodash": "4.17.5"
+			}
+		},
+		"babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.5",
+				"to-fast-properties": "1.0.3"
+			}
+		},
+		"babylon": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+		},
+		"balanced-match": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+			"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+		},
+		"base": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"requires": {
+				"cache-base": "1.0.1",
+				"class-utils": "0.3.6",
+				"component-emitter": "1.2.1",
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"mixin-deep": "1.3.1",
+				"pascalcase": "0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"base64-js": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
+			"integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w=="
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"optional": true,
+			"requires": {
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"big.js": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+		},
+		"binary-extensions": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+		},
+		"bn.js": {
+			"version": "4.11.8",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+		},
+		"boom": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+			"requires": {
+				"hoek": "4.2.1"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "1.0.0",
+				"concat-map": "0.0.1"
+			},
+			"dependencies": {
+				"balanced-match": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+				}
+			}
+		},
+		"braces": {
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"requires": {
+				"expand-range": "1.8.2",
+				"preserve": "0.2.0",
+				"repeat-element": "1.1.2"
+			}
+		},
+		"brorand": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+		},
+		"browser-process-hrtime": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
+		},
+		"browser-resolve": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+			"integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+			"requires": {
+				"resolve": "1.1.7"
+			}
+		},
+		"browserify-aes": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
+			"integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+			"requires": {
+				"buffer-xor": "1.0.3",
+				"cipher-base": "1.0.4",
+				"create-hash": "1.1.3",
+				"evp_bytestokey": "1.0.3",
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"browserify-cipher": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+			"integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+			"requires": {
+				"browserify-aes": "1.1.1",
+				"browserify-des": "1.0.0",
+				"evp_bytestokey": "1.0.3"
+			}
+		},
+		"browserify-des": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+			"integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+			"requires": {
+				"cipher-base": "1.0.4",
+				"des.js": "1.0.0",
+				"inherits": "2.0.3"
+			}
+		},
+		"browserify-rsa": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+			"requires": {
+				"bn.js": "4.11.8",
+				"randombytes": "2.0.6"
+			}
+		},
+		"browserify-sign": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+			"requires": {
+				"bn.js": "4.11.8",
+				"browserify-rsa": "4.0.1",
+				"create-hash": "1.1.3",
+				"create-hmac": "1.1.6",
+				"elliptic": "6.4.0",
+				"inherits": "2.0.3",
+				"parse-asn1": "5.1.0"
+			}
+		},
+		"browserify-zlib": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+			"requires": {
+				"pako": "1.0.6"
+			}
+		},
+		"browserslist": {
+			"version": "1.7.7",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+			"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+			"requires": {
+				"caniuse-db": "1.0.30000813",
+				"electron-to-chromium": "1.3.36"
+			}
+		},
+		"bser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+			"requires": {
+				"node-int64": "0.4.0"
+			}
+		},
+		"buffer": {
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+			"requires": {
+				"base64-js": "1.2.3",
+				"ieee754": "1.1.8",
+				"isarray": "1.0.0"
+			}
+		},
+		"buffer-xor": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+		},
+		"builtin-status-codes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+		},
+		"cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"requires": {
+				"collection-visit": "1.0.0",
+				"component-emitter": "1.2.1",
+				"get-value": "2.0.6",
+				"has-value": "1.0.0",
+				"isobject": "3.0.1",
+				"set-value": "2.0.0",
+				"to-object-path": "0.3.0",
+				"union-value": "1.0.0",
+				"unset-value": "1.0.0"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"callsites": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+		},
+		"camelcase": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+		},
+		"caniuse-api": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+			"integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
+			"requires": {
+				"browserslist": "1.7.7",
+				"caniuse-db": "1.0.30000813",
+				"lodash.memoize": "4.1.2",
+				"lodash.uniq": "4.5.0"
+			}
+		},
+		"caniuse-db": {
+			"version": "1.0.30000813",
+			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000813.tgz",
+			"integrity": "sha1-4KHGA/iICteHsqNWUrJzPzKl4po="
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+		},
+		"center-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+			"requires": {
+				"align-text": "0.1.4",
+				"lazy-cache": "1.0.4"
+			}
+		},
+		"chalk": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"requires": {
+				"ansi-styles": "2.2.1",
+				"escape-string-regexp": "1.0.5",
+				"has-ansi": "2.0.0",
+				"strip-ansi": "3.0.1",
+				"supports-color": "2.0.0"
+			}
+		},
+		"chokidar": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.2.tgz",
+			"integrity": "sha512-l32Hw3wqB0L2kGVmSbK/a+xXLDrUEsc84pSgMkmwygHvD7ubRsP/vxxHa5BtB6oix1XLLVCHyYMsckRXxThmZw==",
+			"requires": {
+				"anymatch": "2.0.0",
+				"async-each": "1.0.1",
+				"braces": "2.3.1",
+				"fsevents": "1.1.3",
+				"glob-parent": "3.1.0",
+				"inherits": "2.0.3",
+				"is-binary-path": "1.0.1",
+				"is-glob": "4.0.0",
+				"normalize-path": "2.1.1",
+				"path-is-absolute": "1.0.1",
+				"readdirp": "2.1.0",
+				"upath": "1.0.4"
+			},
+			"dependencies": {
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"requires": {
+						"micromatch": "3.1.9",
+						"normalize-path": "2.1.1"
+					}
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"braces": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
+					"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+					"requires": {
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"kind-of": "6.0.2",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.1",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"requires": {
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.1",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"requires": {
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.1",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"glob-parent": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+					"requires": {
+						"is-glob": "3.1.0",
+						"path-dirname": "1.0.2"
+					},
+					"dependencies": {
+						"is-glob": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+							"requires": {
+								"is-extglob": "2.1.1"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+				},
+				"is-glob": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+					"requires": {
+						"is-extglob": "2.1.1"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"micromatch": {
+					"version": "3.1.9",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
+					"integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
+					"requires": {
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.1",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.1",
+						"to-regex": "3.0.2"
+					}
+				}
+			}
+		},
+		"ci-info": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+			"integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA=="
+		},
+		"cipher-base": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"requires": {
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"clap": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
+			"integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+			"requires": {
+				"chalk": "1.1.3"
+			}
+		},
+		"class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"requires": {
+				"arr-union": "3.1.0",
+				"define-property": "0.2.5",
+				"isobject": "3.0.1",
+				"static-extend": "0.1.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+				}
+			}
+		},
+		"cliui": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"requires": {
+				"center-align": "0.1.3",
+				"right-align": "0.1.3",
+				"wordwrap": "0.0.2"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+				}
+			}
+		},
+		"clone": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+			"integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+		},
+		"coa": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+			"integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+			"requires": {
+				"q": "1.5.1"
+			}
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+		},
+		"collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"requires": {
+				"map-visit": "1.0.0",
+				"object-visit": "1.0.1"
+			}
+		},
+		"color": {
+			"version": "0.11.4",
+			"resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+			"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+			"requires": {
+				"clone": "1.0.3",
+				"color-convert": "1.9.1",
+				"color-string": "0.3.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"color-string": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+			"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"colormin": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+			"integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
+			"requires": {
+				"color": "0.11.4",
+				"css-color-names": "0.0.4",
+				"has": "1.0.1"
+			}
+		},
+		"colors": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+		},
+		"combined-stream": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"requires": {
+				"delayed-stream": "1.0.0"
+			}
+		},
+		"commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+		},
+		"component-emitter": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"console-browserify": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+			"requires": {
+				"date-now": "0.1.4"
+			}
+		},
+		"constants-browserify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
+		},
+		"content-type-parser": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
+			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
+		},
+		"convert-source-map": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+		},
+		"copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+		},
+		"core-js": {
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"create-ecdh": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+			"integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+			"requires": {
+				"bn.js": "4.11.8",
+				"elliptic": "6.4.0"
+			}
+		},
+		"create-hash": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+			"integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+			"requires": {
+				"cipher-base": "1.0.4",
+				"inherits": "2.0.3",
+				"ripemd160": "2.0.1",
+				"sha.js": "2.4.10"
+			}
+		},
+		"create-hmac": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+			"integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+			"requires": {
+				"cipher-base": "1.0.4",
+				"create-hash": "1.1.3",
+				"inherits": "2.0.3",
+				"ripemd160": "2.0.1",
+				"safe-buffer": "5.1.1",
+				"sha.js": "2.4.10"
+			}
+		},
+		"cross-spawn": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"requires": {
+				"lru-cache": "4.1.1",
+				"shebang-command": "1.2.0",
+				"which": "1.3.0"
+			}
+		},
+		"cryptiles": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+			"requires": {
+				"boom": "5.2.0"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+					"requires": {
+						"hoek": "4.2.1"
+					}
+				}
+			}
+		},
+		"crypto-browserify": {
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+			"requires": {
+				"browserify-cipher": "1.0.0",
+				"browserify-sign": "4.0.4",
+				"create-ecdh": "4.0.0",
+				"create-hash": "1.1.3",
+				"create-hmac": "1.1.6",
+				"diffie-hellman": "5.0.2",
+				"inherits": "2.0.3",
+				"pbkdf2": "3.0.14",
+				"public-encrypt": "4.0.0",
+				"randombytes": "2.0.6",
+				"randomfill": "1.0.4"
+			}
+		},
+		"css-color-names": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+			"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
+		},
+		"css-loader": {
+			"version": "0.28.10",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.10.tgz",
+			"integrity": "sha512-X1IJteKnW9Llmrd+lJ0f7QZHh9Arf+11S7iRcoT2+riig3BK0QaCaOtubAulMK6Itbo08W6d3l8sW21r+Jhp5Q==",
+			"requires": {
+				"babel-code-frame": "6.26.0",
+				"css-selector-tokenizer": "0.7.0",
+				"cssnano": "3.10.0",
+				"icss-utils": "2.1.0",
+				"loader-utils": "1.1.0",
+				"lodash.camelcase": "4.3.0",
+				"object-assign": "4.1.1",
+				"postcss": "5.2.18",
+				"postcss-modules-extract-imports": "1.2.0",
+				"postcss-modules-local-by-default": "1.2.0",
+				"postcss-modules-scope": "1.1.0",
+				"postcss-modules-values": "1.3.0",
+				"postcss-value-parser": "3.3.0",
+				"source-list-map": "2.0.0"
+			}
+		},
+		"css-selector-tokenizer": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+			"integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+			"requires": {
+				"cssesc": "0.1.0",
+				"fastparse": "1.1.1",
+				"regexpu-core": "1.0.0"
+			}
+		},
+		"cssesc": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+			"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q="
+		},
+		"cssnano": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+			"integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
+			"requires": {
+				"autoprefixer": "6.7.7",
+				"decamelize": "1.2.0",
+				"defined": "1.0.0",
+				"has": "1.0.1",
+				"object-assign": "4.1.1",
+				"postcss": "5.2.18",
+				"postcss-calc": "5.3.1",
+				"postcss-colormin": "2.2.2",
+				"postcss-convert-values": "2.6.1",
+				"postcss-discard-comments": "2.0.4",
+				"postcss-discard-duplicates": "2.1.0",
+				"postcss-discard-empty": "2.1.0",
+				"postcss-discard-overridden": "0.1.1",
+				"postcss-discard-unused": "2.2.3",
+				"postcss-filter-plugins": "2.0.2",
+				"postcss-merge-idents": "2.1.7",
+				"postcss-merge-longhand": "2.0.2",
+				"postcss-merge-rules": "2.1.2",
+				"postcss-minify-font-values": "1.0.5",
+				"postcss-minify-gradients": "1.0.5",
+				"postcss-minify-params": "1.2.2",
+				"postcss-minify-selectors": "2.1.1",
+				"postcss-normalize-charset": "1.1.1",
+				"postcss-normalize-url": "3.0.8",
+				"postcss-ordered-values": "2.2.3",
+				"postcss-reduce-idents": "2.4.0",
+				"postcss-reduce-initial": "1.0.1",
+				"postcss-reduce-transforms": "1.0.4",
+				"postcss-svgo": "2.1.6",
+				"postcss-unique-selectors": "2.0.2",
+				"postcss-value-parser": "3.3.0",
+				"postcss-zindex": "2.2.0"
+			}
+		},
+		"csso": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+			"integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
+			"requires": {
+				"clap": "1.2.3",
+				"source-map": "0.5.7"
+			}
+		},
+		"cssom": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+		},
+		"cssstyle": {
+			"version": "0.2.37",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+			"requires": {
+				"cssom": "0.3.2"
+			}
+		},
+		"d": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+			"requires": {
+				"es5-ext": "0.10.39"
+			}
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"requires": {
+				"assert-plus": "1.0.0"
+			}
+		},
+		"date-now": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
+		},
+		"debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+		},
+		"decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+		},
+		"default-require-extensions": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+			"requires": {
+				"strip-bom": "2.0.0"
+			}
+		},
+		"define-properties": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"requires": {
+				"foreach": "2.0.5",
+				"object-keys": "1.0.11"
+			}
+		},
+		"define-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"requires": {
+				"is-descriptor": "1.0.2",
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"defined": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+		},
+		"des.js": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+			"requires": {
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0"
+			}
+		},
+		"detect-indent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"requires": {
+				"repeating": "2.0.1"
+			}
+		},
+		"detect-newline": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+		},
+		"diff": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+		},
+		"diffie-hellman": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+			"integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+			"requires": {
+				"bn.js": "4.11.8",
+				"miller-rabin": "4.0.1",
+				"randombytes": "2.0.6"
+			}
+		},
+		"domain-browser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
+		},
+		"domexception": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"requires": {
+				"webidl-conversions": "4.0.2"
+			}
+		},
+		"ecc-jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"optional": true,
+			"requires": {
+				"jsbn": "0.1.1"
+			}
+		},
+		"electron-to-chromium": {
+			"version": "1.3.36",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.36.tgz",
+			"integrity": "sha1-Dqv3Gp6+qQE/scw1o5DgaGJPJ+g="
+		},
+		"elliptic": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+			"requires": {
+				"bn.js": "4.11.8",
+				"brorand": "1.1.0",
+				"hash.js": "1.1.3",
+				"hmac-drbg": "1.0.1",
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0",
+				"minimalistic-crypto-utils": "1.0.1"
+			}
+		},
+		"emojis-list": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+		},
+		"enhanced-resolve": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"memory-fs": "0.4.1",
+				"object-assign": "4.1.1",
+				"tapable": "0.2.8"
+			}
+		},
+		"errno": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+			"requires": {
+				"prr": "1.0.1"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"requires": {
+				"is-arrayish": "0.2.1"
+			}
+		},
+		"es-abstract": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
+			"integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+			"requires": {
+				"es-to-primitive": "1.1.1",
+				"function-bind": "1.1.1",
+				"has": "1.0.1",
+				"is-callable": "1.1.3",
+				"is-regex": "1.0.4"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"requires": {
+				"is-callable": "1.1.3",
+				"is-date-object": "1.0.1",
+				"is-symbol": "1.0.1"
+			}
+		},
+		"es5-ext": {
+			"version": "0.10.39",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.39.tgz",
+			"integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
+			"requires": {
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"es6-iterator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.39",
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"es6-map": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.39",
+				"es6-iterator": "2.0.3",
+				"es6-set": "0.1.5",
+				"es6-symbol": "3.1.1",
+				"event-emitter": "0.3.5"
+			}
+		},
+		"es6-set": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.39",
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1",
+				"event-emitter": "0.3.5"
+			}
+		},
+		"es6-symbol": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.39"
+			}
+		},
+		"es6-weak-map": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.39",
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"escodegen": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+			"requires": {
+				"esprima": "3.1.3",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"optional": true
+				}
+			}
+		},
+		"escope": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+			"requires": {
+				"es6-map": "0.1.5",
+				"es6-weak-map": "2.0.2",
+				"esrecurse": "4.2.1",
+				"estraverse": "4.2.0"
+			}
+		},
+		"esprima": {
+			"version": "2.7.3",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+			"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+		},
+		"esrecurse": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"requires": {
+				"estraverse": "4.2.0"
+			}
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+		},
+		"event-emitter": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.39"
+			}
+		},
+		"events": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+		},
+		"evp_bytestokey": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+			"requires": {
+				"md5.js": "1.3.4",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"exec-sh": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
+			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
+			"requires": {
+				"merge": "1.2.0"
+			}
+		},
+		"execa": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"requires": {
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
+			}
+		},
+		"exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+		},
+		"expand-brackets": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"requires": {
+				"is-posix-bracket": "0.1.1"
+			}
+		},
+		"expand-range": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"requires": {
+				"fill-range": "2.2.3"
+			}
+		},
+		"expect": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-22.4.0.tgz",
+			"integrity": "sha512-Fiy862jT3qc70hwIHwwCBNISmaqBrfWKKrtqyMJ6iwZr+6KXtcnHojZFtd63TPRvRl8EQTJ+YXYy2lK6/6u+Hw==",
+			"requires": {
+				"ansi-styles": "3.2.1",
+				"jest-diff": "22.4.0",
+				"jest-get-type": "22.1.0",
+				"jest-matcher-utils": "22.4.0",
+				"jest-message-util": "22.4.0",
+				"jest-regex-util": "22.1.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				}
+			}
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"requires": {
+				"assign-symbols": "1.0.0",
+				"is-extendable": "1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "2.0.4"
+					}
+				}
+			}
+		},
+		"extglob": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"requires": {
+				"is-extglob": "1.0.0"
+			}
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+		},
+		"fast-deep-equal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+		},
+		"fastparse": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+			"integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
+		},
+		"fb-watchman": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+			"requires": {
+				"bser": "2.0.0"
+			}
+		},
+		"filename-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+		},
+		"fileset": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+			"requires": {
+				"glob": "7.1.2",
+				"minimatch": "3.0.4"
+			}
+		},
+		"fill-range": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"requires": {
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "1.1.7",
+				"repeat-element": "1.1.2",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"find-cache-dir": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+			"requires": {
+				"commondir": "1.0.1",
+				"make-dir": "1.2.0",
+				"pkg-dir": "2.0.0"
+			}
+		},
+		"find-up": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"requires": {
+				"locate-path": "2.0.0"
+			}
+		},
+		"flatten": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"requires": {
+				"for-in": "1.0.2"
+			}
+		},
+		"foreach": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+		},
+		"form-data": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"requires": {
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.6",
+				"mime-types": "2.1.18"
+			}
+		},
+		"fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"requires": {
+				"map-cache": "0.2.2"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"fsevents": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+			"optional": true,
+			"requires": {
+				"nan": "2.9.2",
+				"node-pre-gyp": "0.6.39"
+			},
+			"dependencies": {
+				"abbrev": {
+					"version": "1.1.0",
+					"bundled": true,
+					"optional": true
+				},
+				"ajv": {
+					"version": "4.11.8",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"co": "4.6.0",
+						"json-stable-stringify": "1.0.1"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"aproba": {
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"are-we-there-yet": {
+					"version": "1.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"delegates": "1.0.0",
+						"readable-stream": "2.2.9"
+					}
+				},
+				"asn1": {
+					"version": "0.2.3",
+					"bundled": true,
+					"optional": true
+				},
+				"assert-plus": {
+					"version": "0.2.0",
+					"bundled": true,
+					"optional": true
+				},
+				"asynckit": {
+					"version": "0.4.0",
+					"bundled": true,
+					"optional": true
+				},
+				"aws-sign2": {
+					"version": "0.6.0",
+					"bundled": true,
+					"optional": true
+				},
+				"aws4": {
+					"version": "1.6.0",
+					"bundled": true,
+					"optional": true
+				},
+				"balanced-match": {
+					"version": "0.4.2",
+					"bundled": true
+				},
+				"bcrypt-pbkdf": {
+					"version": "1.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"tweetnacl": "0.14.5"
+					}
+				},
+				"block-stream": {
+					"version": "0.0.9",
+					"bundled": true,
+					"requires": {
+						"inherits": "2.0.3"
+					}
+				},
+				"boom": {
+					"version": "2.10.1",
+					"bundled": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.7",
+					"bundled": true,
+					"requires": {
+						"balanced-match": "0.4.2",
+						"concat-map": "0.0.1"
+					}
+				},
+				"buffer-shims": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"caseless": {
+					"version": "0.12.0",
+					"bundled": true,
+					"optional": true
+				},
+				"co": {
+					"version": "4.6.0",
+					"bundled": true,
+					"optional": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"combined-stream": {
+					"version": "1.0.5",
+					"bundled": true,
+					"requires": {
+						"delayed-stream": "1.0.0"
+					}
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"cryptiles": {
+					"version": "2.0.5",
+					"bundled": true,
+					"requires": {
+						"boom": "2.10.1"
+					}
+				},
+				"dashdash": {
+					"version": "1.14.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.8",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"deep-extend": {
+					"version": "0.4.2",
+					"bundled": true,
+					"optional": true
+				},
+				"delayed-stream": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"detect-libc": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"ecc-jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"extend": {
+					"version": "3.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"extsprintf": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"forever-agent": {
+					"version": "0.6.1",
+					"bundled": true,
+					"optional": true
+				},
+				"form-data": {
+					"version": "2.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"asynckit": "0.4.0",
+						"combined-stream": "1.0.5",
+						"mime-types": "2.1.15"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"fstream": {
+					"version": "1.0.11",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"inherits": "2.0.3",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.1"
+					}
+				},
+				"fstream-ignore": {
+					"version": "1.0.5",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"fstream": "1.0.11",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4"
+					}
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"aproba": "1.1.1",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
+					}
+				},
+				"getpass": {
+					"version": "0.1.7",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true
+				},
+				"har-schema": {
+					"version": "1.0.5",
+					"bundled": true,
+					"optional": true
+				},
+				"har-validator": {
+					"version": "4.2.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"ajv": "4.11.8",
+						"har-schema": "1.0.5"
+					}
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"hawk": {
+					"version": "3.1.3",
+					"bundled": true,
+					"requires": {
+						"boom": "2.10.1",
+						"cryptiles": "2.0.5",
+						"hoek": "2.16.3",
+						"sntp": "1.0.9"
+					}
+				},
+				"hoek": {
+					"version": "2.16.3",
+					"bundled": true
+				},
+				"http-signature": {
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "0.2.0",
+						"jsprim": "1.4.0",
+						"sshpk": "1.13.0"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"ini": {
+					"version": "1.3.4",
+					"bundled": true,
+					"optional": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-typedarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"isstream": {
+					"version": "0.1.2",
+					"bundled": true,
+					"optional": true
+				},
+				"jodid25519": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"json-schema": {
+					"version": "0.2.3",
+					"bundled": true,
+					"optional": true
+				},
+				"json-stable-stringify": {
+					"version": "1.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"jsonify": "0.0.0"
+					}
+				},
+				"json-stringify-safe": {
+					"version": "5.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"jsonify": {
+					"version": "0.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"jsprim": {
+					"version": "1.4.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.0.2",
+						"json-schema": "0.2.3",
+						"verror": "1.3.6"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"mime-db": {
+					"version": "1.27.0",
+					"bundled": true
+				},
+				"mime-types": {
+					"version": "2.1.15",
+					"bundled": true,
+					"requires": {
+						"mime-db": "1.27.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"brace-expansion": "1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"node-pre-gyp": {
+					"version": "0.6.39",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"detect-libc": "1.0.2",
+						"hawk": "3.1.3",
+						"mkdirp": "0.5.1",
+						"nopt": "4.0.1",
+						"npmlog": "4.1.0",
+						"rc": "1.2.1",
+						"request": "2.81.0",
+						"rimraf": "2.6.1",
+						"semver": "5.3.0",
+						"tar": "2.2.1",
+						"tar-pack": "3.4.0"
+					}
+				},
+				"nopt": {
+					"version": "4.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"abbrev": "1.1.0",
+						"osenv": "0.1.4"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"oauth-sign": {
+					"version": "0.8.2",
+					"bundled": true,
+					"optional": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"osenv": {
+					"version": "0.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"performance-now": {
+					"version": "0.2.0",
+					"bundled": true,
+					"optional": true
+				},
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"bundled": true
+				},
+				"punycode": {
+					"version": "1.4.1",
+					"bundled": true,
+					"optional": true
+				},
+				"qs": {
+					"version": "6.4.0",
+					"bundled": true,
+					"optional": true
+				},
+				"rc": {
+					"version": "1.2.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"deep-extend": "0.4.2",
+						"ini": "1.3.4",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.2.9",
+					"bundled": true,
+					"requires": {
+						"buffer-shims": "1.0.0",
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "1.0.1",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"request": {
+					"version": "2.81.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"aws-sign2": "0.6.0",
+						"aws4": "1.6.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.1.4",
+						"har-validator": "4.2.1",
+						"hawk": "3.1.3",
+						"http-signature": "1.1.1",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.15",
+						"oauth-sign": "0.8.2",
+						"performance-now": "0.2.0",
+						"qs": "6.4.0",
+						"safe-buffer": "5.0.1",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.2",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.0.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.1",
+					"bundled": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.0.1",
+					"bundled": true
+				},
+				"semver": {
+					"version": "5.3.0",
+					"bundled": true,
+					"optional": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"sntp": {
+					"version": "1.0.9",
+					"bundled": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"sshpk": {
+					"version": "1.13.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"asn1": "0.2.3",
+						"assert-plus": "1.0.0",
+						"bcrypt-pbkdf": "1.0.1",
+						"dashdash": "1.14.1",
+						"ecc-jsbn": "0.1.1",
+						"getpass": "0.1.7",
+						"jodid25519": "1.0.2",
+						"jsbn": "0.1.1",
+						"tweetnacl": "0.14.5"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"stringstream": {
+					"version": "0.0.5",
+					"bundled": true,
+					"optional": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"tar": {
+					"version": "2.2.1",
+					"bundled": true,
+					"requires": {
+						"block-stream": "0.0.9",
+						"fstream": "1.0.11",
+						"inherits": "2.0.3"
+					}
+				},
+				"tar-pack": {
+					"version": "3.4.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"debug": "2.6.8",
+						"fstream": "1.0.11",
+						"fstream-ignore": "1.0.5",
+						"once": "1.4.0",
+						"readable-stream": "2.2.9",
+						"rimraf": "2.6.1",
+						"tar": "2.2.1",
+						"uid-number": "0.0.6"
+					}
+				},
+				"tough-cookie": {
+					"version": "2.3.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"punycode": "1.4.1"
+					}
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"tweetnacl": {
+					"version": "0.14.5",
+					"bundled": true,
+					"optional": true
+				},
+				"uid-number": {
+					"version": "0.0.6",
+					"bundled": true,
+					"optional": true
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"uuid": {
+					"version": "3.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"verror": {
+					"version": "1.3.6",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"extsprintf": "1.0.2"
+					}
+				},
+				"wide-align": {
+					"version": "1.1.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"string-width": "1.0.2"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true
+				}
+			}
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+		},
+		"get-caller-file": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+		},
+		"get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"requires": {
+				"assert-plus": "1.0.0"
+			}
+		},
+		"glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"requires": {
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
+			}
+		},
+		"glob-base": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"requires": {
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
+			}
+		},
+		"glob-parent": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"requires": {
+				"is-glob": "2.0.1"
+			}
+		},
+		"globals": {
+			"version": "9.18.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+		},
+		"graceful-fs": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+		},
+		"growly": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+		},
+		"handlebars": {
+			"version": "4.0.11",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+			"requires": {
+				"async": "1.5.2",
+				"optimist": "0.6.1",
+				"source-map": "0.4.4",
+				"uglify-js": "2.8.29"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+				},
+				"source-map": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"requires": {
+						"amdefine": "1.0.1"
+					}
+				}
+			}
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+		},
+		"har-validator": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"requires": {
+				"ajv": "5.5.2",
+				"har-schema": "2.0.0"
+			}
+		},
+		"has": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"requires": {
+				"function-bind": "1.1.1"
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+		},
+		"has-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"requires": {
+				"get-value": "2.0.6",
+				"has-values": "1.0.0",
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"has-values": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
+		},
+		"hash-base": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+			"integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+			"requires": {
+				"inherits": "2.0.3"
+			}
+		},
+		"hash.js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+			"requires": {
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0"
+			}
+		},
+		"hawk": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+			"requires": {
+				"boom": "4.3.1",
+				"cryptiles": "3.1.2",
+				"hoek": "4.2.1",
+				"sntp": "2.1.0"
+			}
+		},
+		"hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"requires": {
+				"hash.js": "1.1.3",
+				"minimalistic-assert": "1.0.0",
+				"minimalistic-crypto-utils": "1.0.1"
+			}
+		},
+		"hoek": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+		},
+		"home-or-tmp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"requires": {
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
+			}
+		},
+		"hosted-git-info": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+		},
+		"html-comment-regex": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
+			"integrity": "sha1-ZouTd26q5V696POtRkswekljYl4="
+		},
+		"html-encoding-sniffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"requires": {
+				"whatwg-encoding": "1.0.3"
+			}
+		},
+		"http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.13.1"
+			}
+		},
+		"https-browserify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
+		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+		},
+		"icss-replace-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+			"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
+		},
+		"icss-utils": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
+			"integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+			"requires": {
+				"postcss": "6.0.19"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"postcss": {
+					"version": "6.0.19",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
+					"integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+					"requires": {
+						"chalk": "2.3.2",
+						"source-map": "0.6.1",
+						"supports-color": "5.3.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"ieee754": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+		},
+		"import-local": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+			"requires": {
+				"pkg-dir": "2.0.0",
+				"resolve-cwd": "2.0.0"
+			}
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+		},
+		"indexes-of": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+		},
+		"indexof": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"interpret": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+		},
+		"invariant": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
+			"integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+			"requires": {
+				"loose-envify": "1.3.1"
+			}
+		},
+		"invert-kv": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+		},
+		"is-absolute-url": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+			"integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY="
+		},
+		"is-accessor-descriptor": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+			"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+			"requires": {
+				"kind-of": "6.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+		},
+		"is-binary-path": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"requires": {
+				"binary-extensions": "1.11.0"
+			}
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+		},
+		"is-builtin-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"requires": {
+				"builtin-modules": "1.1.1"
+			}
+		},
+		"is-callable": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+		},
+		"is-ci": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+			"requires": {
+				"ci-info": "1.1.2"
+			}
+		},
+		"is-data-descriptor": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+			"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+			"requires": {
+				"kind-of": "6.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+		},
+		"is-descriptor": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+			"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+			"requires": {
+				"is-accessor-descriptor": "1.0.0",
+				"is-data-descriptor": "1.0.0",
+				"kind-of": "6.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
+		"is-dotfile": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+		},
+		"is-equal-shallow": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"requires": {
+				"is-primitive": "2.0.0"
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+		},
+		"is-extglob": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+		},
+		"is-finite": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"requires": {
+				"number-is-nan": "1.0.1"
+			}
+		},
+		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+		},
+		"is-generator-fn": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
+			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go="
+		},
+		"is-glob": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"requires": {
+				"is-extglob": "1.0.0"
+			}
+		},
+		"is-number": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"is-odd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+			"requires": {
+				"is-number": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+				}
+			}
+		},
+		"is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"requires": {
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"is-posix-bracket": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+		},
+		"is-primitive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"requires": {
+				"has": "1.0.1"
+			}
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"is-svg": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+			"integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
+			"requires": {
+				"html-comment-regex": "1.1.1"
+			}
+		},
+		"is-symbol": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+		},
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+		},
+		"isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"requires": {
+				"isarray": "1.0.0"
+			}
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"istanbul-api": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.2.2.tgz",
+			"integrity": "sha512-kH5YRdqdbs5hiH4/Rr1Q0cSAGgjh3jTtg8vu9NLebBAoK3adVO4jk81J+TYOkTr2+Q4NLeb1ACvmEt65iG/Vbw==",
+			"requires": {
+				"async": "2.6.0",
+				"fileset": "2.0.3",
+				"istanbul-lib-coverage": "1.1.2",
+				"istanbul-lib-hook": "1.1.0",
+				"istanbul-lib-instrument": "1.9.2",
+				"istanbul-lib-report": "1.1.3",
+				"istanbul-lib-source-maps": "1.2.3",
+				"istanbul-reports": "1.1.4",
+				"js-yaml": "3.7.0",
+				"mkdirp": "0.5.1",
+				"once": "1.4.0"
+			}
+		},
+		"istanbul-lib-coverage": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.2.tgz",
+			"integrity": "sha512-tZYA0v5A7qBSsOzcebJJ/z3lk3oSzH62puG78DbBA1+zupipX2CakDyiPV3pOb8He+jBwVimuwB0dTnh38hX0w=="
+		},
+		"istanbul-lib-hook": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
+			"integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
+			"requires": {
+				"append-transform": "0.4.0"
+			}
+		},
+		"istanbul-lib-instrument": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.2.tgz",
+			"integrity": "sha512-nz8t4HQ2206a/3AXi+NHFWEa844DMpPsgbcUteJbt1j8LX1xg56H9rOMnhvcvVvPbW60qAIyrSk44H8ZDqaSSA==",
+			"requires": {
+				"babel-generator": "6.26.1",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"istanbul-lib-coverage": "1.1.2",
+				"semver": "5.5.0"
+			}
+		},
+		"istanbul-lib-report": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz",
+			"integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
+			"requires": {
+				"istanbul-lib-coverage": "1.1.2",
+				"mkdirp": "0.5.1",
+				"path-parse": "1.0.5",
+				"supports-color": "3.2.3"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-lib-source-maps": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
+			"integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+			"requires": {
+				"debug": "3.1.0",
+				"istanbul-lib-coverage": "1.1.2",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"source-map": "0.5.7"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-reports": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.4.tgz",
+			"integrity": "sha512-DfSTVOTkuO+kRmbO8Gk650Wqm1WRGr6lrdi2EwDK1vxpS71vdlLd613EpzOKdIFioB5f/scJTjeWBnvd1FWejg==",
+			"requires": {
+				"handlebars": "4.0.11"
+			}
+		},
+		"jest": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-22.4.2.tgz",
+			"integrity": "sha512-wD7dXWtfaQAgbNVsjFqzmuhg6nzwGsTRVea3FpSJ7GURhG+J536fw4mdoLB01DgiEozDDeF1ZMR/UlUszTsCrg==",
+			"requires": {
+				"import-local": "1.0.0",
+				"jest-cli": "22.4.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"jest-cli": {
+					"version": "22.4.2",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.2.tgz",
+					"integrity": "sha512-ebo6ZWK2xDSs7LGnLvM16SZOIJ2dj0B6/oERmGcal32NHkks450nNfGrGTyOSPgJDgH8DFhVdBXgSamN7mtZ0Q==",
+					"requires": {
+						"ansi-escapes": "3.0.0",
+						"chalk": "2.3.2",
+						"exit": "0.1.2",
+						"glob": "7.1.2",
+						"graceful-fs": "4.1.11",
+						"import-local": "1.0.0",
+						"is-ci": "1.1.0",
+						"istanbul-api": "1.2.2",
+						"istanbul-lib-coverage": "1.1.2",
+						"istanbul-lib-instrument": "1.9.2",
+						"istanbul-lib-source-maps": "1.2.3",
+						"jest-changed-files": "22.2.0",
+						"jest-config": "22.4.2",
+						"jest-environment-jsdom": "22.4.1",
+						"jest-get-type": "22.1.0",
+						"jest-haste-map": "22.4.2",
+						"jest-message-util": "22.4.0",
+						"jest-regex-util": "22.1.0",
+						"jest-resolve-dependencies": "22.1.0",
+						"jest-runner": "22.4.2",
+						"jest-runtime": "22.4.2",
+						"jest-snapshot": "22.4.0",
+						"jest-util": "22.4.1",
+						"jest-validate": "22.4.2",
+						"jest-worker": "22.2.2",
+						"micromatch": "2.3.11",
+						"node-notifier": "5.2.1",
+						"realpath-native": "1.0.0",
+						"rimraf": "2.6.2",
+						"slash": "1.0.0",
+						"string-length": "2.0.0",
+						"strip-ansi": "4.0.0",
+						"which": "1.3.0",
+						"yargs": "10.1.2"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"jest-changed-files": {
+			"version": "22.2.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.2.0.tgz",
+			"integrity": "sha512-SzqOvoPMrXB0NPvDrSPeKETpoUNCtNDOsFbCzAGWxqWVvNyrIMLpUjVExT3u3LfdVrENlrNGCfh5YoFd8+ZeXg==",
+			"requires": {
+				"throat": "4.1.0"
+			}
+		},
+		"jest-config": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.2.tgz",
+			"integrity": "sha512-oG31qYO73/3vj/Q8aM2RgzmHndTkz9nRk8ISybfuJqqbf0RW7OUjHVOZPLOUiwLWtz52Yq2HkjIblsyhbA7vrg==",
+			"requires": {
+				"chalk": "2.3.2",
+				"glob": "7.1.2",
+				"jest-environment-jsdom": "22.4.1",
+				"jest-environment-node": "22.4.1",
+				"jest-get-type": "22.1.0",
+				"jest-jasmine2": "22.4.2",
+				"jest-regex-util": "22.1.0",
+				"jest-resolve": "22.4.2",
+				"jest-util": "22.4.1",
+				"jest-validate": "22.4.2",
+				"pretty-format": "22.4.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"jest-diff": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.0.tgz",
+			"integrity": "sha512-+/t20WmnkOkB8MOaGaPziI8zWKxquMvYw4Ub+wOzi7AUhmpFXz43buWSxVoZo4J5RnCozpGbX3/FssjJ5KV9Nw==",
+			"requires": {
+				"chalk": "2.3.2",
+				"diff": "3.5.0",
+				"jest-get-type": "22.1.0",
+				"pretty-format": "22.4.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"jest-docblock": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.0.tgz",
+			"integrity": "sha512-lDY7GZ+/CJb02oULYLBDj7Hs5shBhVpDYpIm8LUyqw9X2J22QRsM19gmGQwIFqGSJmpc/LRrSYudeSrG510xlQ==",
+			"requires": {
+				"detect-newline": "2.1.0"
+			}
+		},
+		"jest-environment-jsdom": {
+			"version": "22.4.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.1.tgz",
+			"integrity": "sha512-x/JzAoH+dWPBnIMv5OQKiIR0TYf6UvbRjsIuDZ11yDFXkHKGJZg6jNnLAsokAm3cq9kUa2hH5BPUC9XU4n1ELQ==",
+			"requires": {
+				"jest-mock": "22.2.0",
+				"jest-util": "22.4.1",
+				"jsdom": "11.6.2"
+			}
+		},
+		"jest-environment-node": {
+			"version": "22.4.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.1.tgz",
+			"integrity": "sha512-wj9+zzfRgnUbm5VwFOCGgG1QmbucUyrjPKBKUJdLW8K5Ss5zrNc1k+v6feZhFg6sS3ZGnjgtIyklaxEARxu+LQ==",
+			"requires": {
+				"jest-mock": "22.2.0",
+				"jest-util": "22.4.1"
+			}
+		},
+		"jest-get-type": {
+			"version": "22.1.0",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.1.0.tgz",
+			"integrity": "sha512-nD97IVOlNP6fjIN5i7j5XRH+hFsHL7VlauBbzRvueaaUe70uohrkz7pL/N8lx/IAwZRTJ//wOdVgh85OgM7g3w=="
+		},
+		"jest-haste-map": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.2.tgz",
+			"integrity": "sha512-EdQADHGXRqHJYAr7q9B9YYHZnrlcMwhx1+DnIgc9uN05nCW3RvGCxJ91MqWXcC1AzatLoSv7SNd0qXMp2jKBDA==",
+			"requires": {
+				"fb-watchman": "2.0.0",
+				"graceful-fs": "4.1.11",
+				"jest-docblock": "22.4.0",
+				"jest-serializer": "22.4.0",
+				"jest-worker": "22.2.2",
+				"micromatch": "2.3.11",
+				"sane": "2.4.1"
+			}
+		},
+		"jest-jasmine2": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.2.tgz",
+			"integrity": "sha512-KZaIHpXQ0AIlvQJFCU0uoXxtz5GG47X14r9upMe7VXE55UazoMZBFnQb9TX2HoYX2/AxJYnjHuvwKVCFqOrEtw==",
+			"requires": {
+				"chalk": "2.3.2",
+				"co": "4.6.0",
+				"expect": "22.4.0",
+				"graceful-fs": "4.1.11",
+				"is-generator-fn": "1.0.0",
+				"jest-diff": "22.4.0",
+				"jest-matcher-utils": "22.4.0",
+				"jest-message-util": "22.4.0",
+				"jest-snapshot": "22.4.0",
+				"jest-util": "22.4.1",
+				"source-map-support": "0.5.3"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"jest-leak-detector": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.0.tgz",
+			"integrity": "sha512-r3NEIVNh4X3fEeJtUIrKXWKhNokwUM2ILp5LD8w1KrEanPsFtZmYjmyZYjDTX2dXYr33TW65OvbRE3hWFAyq6g==",
+			"requires": {
+				"pretty-format": "22.4.0"
+			}
+		},
+		"jest-matcher-utils": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.0.tgz",
+			"integrity": "sha512-03m3issxUXpWMwDYTfmL8hRNewUB0yCRTeXPm+eq058rZxLHD9f5NtSSO98CWHqe4UyISIxd9Ao9iDVjHWd2qg==",
+			"requires": {
+				"chalk": "2.3.2",
+				"jest-get-type": "22.1.0",
+				"pretty-format": "22.4.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"jest-message-util": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.0.tgz",
+			"integrity": "sha512-eyCJB0T3hrlpFF2FqQoIB093OulP+1qvATQmD3IOgJgMGqPL6eYw8TbC5P/VCWPqKhGL51xvjIIhow5eZ2wHFw==",
+			"requires": {
+				"@babel/code-frame": "7.0.0-beta.40",
+				"chalk": "2.3.2",
+				"micromatch": "2.3.11",
+				"slash": "1.0.0",
+				"stack-utils": "1.0.1"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"jest-mock": {
+			"version": "22.2.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.2.0.tgz",
+			"integrity": "sha512-eOfoUYLOB/JlxChOFkh/bzpWGqUXb9I+oOpkprHHs9L7nUNfL8Rk28h1ycWrqzWCEQ/jZBg/xIv7VdQkfAkOhw=="
+		},
+		"jest-regex-util": {
+			"version": "22.1.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.1.0.tgz",
+			"integrity": "sha512-on0LqVS6Xeh69sw3d1RukVnur+lVOl3zkmb0Q54FHj9wHoq6dbtWqb3TSlnVUyx36hqjJhjgs/QLqs07Bzu72Q=="
+		},
+		"jest-resolve": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.2.tgz",
+			"integrity": "sha512-P1hSfcc2HJYT5t+WPu/11OfFMa7m8pBb2Gf2vm6W9OVs7YTXQ5RCC3nDqaYZQaTqxEM1ZZaTcQGcE6U2xMOsqQ==",
+			"requires": {
+				"browser-resolve": "1.11.2",
+				"chalk": "2.3.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"jest-resolve-dependencies": {
+			"version": "22.1.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.1.0.tgz",
+			"integrity": "sha512-76Ll61bD/Sus8wK8d+lw891EtiBJGJkWG8OuVDTEX0z3z2+jPujvQqSB2eQ+kCHyCsRwJ2PSjhn3UHqae/oEtA==",
+			"requires": {
+				"jest-regex-util": "22.1.0"
+			}
+		},
+		"jest-runner": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.2.tgz",
+			"integrity": "sha512-W4vwgiVQS0NyXt8hgpw7i0YUtsfoChiQcoHWBJeq2ocV4VF2osEZx8HYgpH5HfNe1Cb5LZeZWxX8Dr3hesbGFg==",
+			"requires": {
+				"exit": "0.1.2",
+				"jest-config": "22.4.2",
+				"jest-docblock": "22.4.0",
+				"jest-haste-map": "22.4.2",
+				"jest-jasmine2": "22.4.2",
+				"jest-leak-detector": "22.4.0",
+				"jest-message-util": "22.4.0",
+				"jest-runtime": "22.4.2",
+				"jest-util": "22.4.1",
+				"jest-worker": "22.2.2",
+				"throat": "4.1.0"
+			}
+		},
+		"jest-runtime": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.2.tgz",
+			"integrity": "sha512-9/Fxbj99cqxI7o2nTNzevnI38eDBstkwve8ZeaAD/Kz0fbU3i3eRv2QPEmzbmyCyBvUWxCT7BzNLTzTqH1+pyA==",
+			"requires": {
+				"babel-core": "6.26.0",
+				"babel-jest": "22.4.1",
+				"babel-plugin-istanbul": "4.1.5",
+				"chalk": "2.3.2",
+				"convert-source-map": "1.5.1",
+				"exit": "0.1.2",
+				"graceful-fs": "4.1.11",
+				"jest-config": "22.4.2",
+				"jest-haste-map": "22.4.2",
+				"jest-regex-util": "22.1.0",
+				"jest-resolve": "22.4.2",
+				"jest-util": "22.4.1",
+				"jest-validate": "22.4.2",
+				"json-stable-stringify": "1.0.1",
+				"micromatch": "2.3.11",
+				"realpath-native": "1.0.0",
+				"slash": "1.0.0",
+				"strip-bom": "3.0.0",
+				"write-file-atomic": "2.3.0",
+				"yargs": "10.1.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"jest-serializer": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.0.tgz",
+			"integrity": "sha512-dnqde95MiYfdc1ZJpjEiHCRvRGGJHPsZQARJFucEGIaOzxqqS9/tt2WzD/OUSGT6kxaEGLQE92faVJGdoCu+Rw=="
+		},
+		"jest-snapshot": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.0.tgz",
+			"integrity": "sha512-6Zz4F9G1Nbr93kfm5h3A2+OkE+WGpgJlskYE4iSNN2uYfoTL5b9W6aB9Orpx+ueReHyqmy7HET7Z3EmYlL3hKw==",
+			"requires": {
+				"chalk": "2.3.2",
+				"jest-diff": "22.4.0",
+				"jest-matcher-utils": "22.4.0",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"pretty-format": "22.4.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"jest-util": {
+			"version": "22.4.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.1.tgz",
+			"integrity": "sha512-9ySBdJY2qVWpg0OvZbGcFXE2NgwccpZVj384E9bx7brKFc7l5anpqah15mseWcz7FLDk7/N+LyYgqFme7Rez2Q==",
+			"requires": {
+				"callsites": "2.0.0",
+				"chalk": "2.3.2",
+				"graceful-fs": "4.1.11",
+				"is-ci": "1.1.0",
+				"jest-message-util": "22.4.0",
+				"mkdirp": "0.5.1",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"jest-validate": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.2.tgz",
+			"integrity": "sha512-TLOgc/EULFBjMCAqZp5OdVvjxV16DZpfthd/UyPzM6lRmgWluohNVemAdnL3JvugU1s2Q2npcIqtbOtiPjaZ0A==",
+			"requires": {
+				"chalk": "2.3.2",
+				"jest-config": "22.4.2",
+				"jest-get-type": "22.1.0",
+				"leven": "2.1.0",
+				"pretty-format": "22.4.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"jest-worker": {
+			"version": "22.2.2",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.2.2.tgz",
+			"integrity": "sha512-ZylDXjrFNt/OP6cUxwJFWwDgazP7hRjtCQbocFHyiwov+04Wm1x5PYzMGNJT53s4nwr0oo9ocYTImS09xOlUnw==",
+			"requires": {
+				"merge-stream": "1.0.1"
+			}
+		},
+		"js-base64": {
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
+			"integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"js-yaml": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+			"integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+			"requires": {
+				"argparse": "1.0.10",
+				"esprima": "2.7.3"
+			}
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"optional": true
+		},
+		"jsdom": {
+			"version": "11.6.2",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
+			"integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
+			"requires": {
+				"abab": "1.0.4",
+				"acorn": "5.5.1",
+				"acorn-globals": "4.1.0",
+				"array-equal": "1.0.0",
+				"browser-process-hrtime": "0.1.2",
+				"content-type-parser": "1.0.2",
+				"cssom": "0.3.2",
+				"cssstyle": "0.2.37",
+				"domexception": "1.0.1",
+				"escodegen": "1.9.1",
+				"html-encoding-sniffer": "1.0.2",
+				"left-pad": "1.2.0",
+				"nwmatcher": "1.4.3",
+				"parse5": "4.0.0",
+				"pn": "1.1.0",
+				"request": "2.83.0",
+				"request-promise-native": "1.0.5",
+				"sax": "1.2.4",
+				"symbol-tree": "3.2.2",
+				"tough-cookie": "2.3.4",
+				"w3c-hr-time": "1.0.1",
+				"webidl-conversions": "4.0.2",
+				"whatwg-encoding": "1.0.3",
+				"whatwg-url": "6.4.0",
+				"ws": "4.1.0",
+				"xml-name-validator": "3.0.0"
+			}
+		},
+		"jsesc": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+		},
+		"json-loader": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+			"integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"requires": {
+				"jsonify": "0.0.0"
+			}
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+		},
+		"json5": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			}
+		},
+		"kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"requires": {
+				"is-buffer": "1.1.6"
+			}
+		},
+		"lazy-cache": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+		},
+		"lcid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"requires": {
+				"invert-kv": "1.0.0"
+			}
+		},
+		"left-pad": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
+			"integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4="
+		},
+		"leven": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"requires": {
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
+			}
+		},
+		"load-json-file": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"parse-json": "2.2.0",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+				}
+			}
+		},
+		"loader-runner": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
+			"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI="
+		},
+		"loader-utils": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+			"requires": {
+				"big.js": "3.2.0",
+				"emojis-list": "2.1.0",
+				"json5": "0.5.1"
+			}
+		},
+		"locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"requires": {
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.5",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+		},
+		"lodash.camelcase": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+		},
+		"lodash.memoize": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+		},
+		"lodash.uniq": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+		},
+		"longest": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+		},
+		"loose-envify": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"requires": {
+				"js-tokens": "3.0.2"
+			}
+		},
+		"lru-cache": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"requires": {
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
+			}
+		},
+		"macaddress": {
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
+			"integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI="
+		},
+		"make-dir": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
+			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+			"requires": {
+				"pify": "3.0.0"
+			}
+		},
+		"makeerror": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+			"requires": {
+				"tmpl": "1.0.4"
+			}
+		},
+		"map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+		},
+		"map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"requires": {
+				"object-visit": "1.0.1"
+			}
+		},
+		"math-expression-evaluator": {
+			"version": "1.2.17",
+			"resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
+			"integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw="
+		},
+		"md5.js": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+			"requires": {
+				"hash-base": "3.0.4",
+				"inherits": "2.0.3"
+			},
+			"dependencies": {
+				"hash-base": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+					"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+					"requires": {
+						"inherits": "2.0.3",
+						"safe-buffer": "5.1.1"
+					}
+				}
+			}
+		},
+		"mem": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"requires": {
+				"mimic-fn": "1.2.0"
+			}
+		},
+		"memory-fs": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+			"requires": {
+				"errno": "0.1.7",
+				"readable-stream": "2.3.5"
+			}
+		},
+		"merge": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"requires": {
+				"readable-stream": "2.3.5"
+			}
+		},
+		"micromatch": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"requires": {
+				"arr-diff": "2.0.0",
+				"array-unique": "0.2.1",
+				"braces": "1.8.5",
+				"expand-brackets": "0.1.5",
+				"extglob": "0.3.2",
+				"filename-regex": "2.0.1",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1",
+				"kind-of": "3.2.2",
+				"normalize-path": "2.1.1",
+				"object.omit": "2.0.1",
+				"parse-glob": "3.0.4",
+				"regex-cache": "0.4.4"
+			}
+		},
+		"miller-rabin": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+			"requires": {
+				"bn.js": "4.11.8",
+				"brorand": "1.1.0"
+			}
+		},
+		"mime-db": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+		},
+		"mime-types": {
+			"version": "2.1.18",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+			"requires": {
+				"mime-db": "1.33.0"
+			}
+		},
+		"mimic-fn": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+		},
+		"minimalistic-assert": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+			"integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+		},
+		"minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "1.1.11"
+			}
+		},
+		"minimist": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+		},
+		"mixin-deep": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"requires": {
+				"for-in": "1.0.2",
+				"is-extendable": "1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "2.0.4"
+					}
+				}
+			}
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"requires": {
+				"minimist": "0.0.8"
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"nan": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+			"integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+			"optional": true
+		},
+		"nanomatch": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+			"requires": {
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"fragment-cache": "0.2.1",
+				"is-odd": "2.0.0",
+				"is-windows": "1.0.2",
+				"kind-of": "6.0.2",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.1",
+				"to-regex": "3.0.2"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+		},
+		"neo-async": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.0.tgz",
+			"integrity": "sha512-nJmSswG4As/MkRq7QZFuH/sf/yuv8ODdMZrY4Bedjp77a5MK4A6s7YbBB64c9u79EBUOfXUXBvArmvzTD0X+6g=="
+		},
+		"node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+		},
+		"node-libs-browser": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+			"requires": {
+				"assert": "1.4.1",
+				"browserify-zlib": "0.2.0",
+				"buffer": "4.9.1",
+				"console-browserify": "1.1.0",
+				"constants-browserify": "1.0.0",
+				"crypto-browserify": "3.12.0",
+				"domain-browser": "1.2.0",
+				"events": "1.1.1",
+				"https-browserify": "1.0.0",
+				"os-browserify": "0.3.0",
+				"path-browserify": "0.0.0",
+				"process": "0.11.10",
+				"punycode": "1.4.1",
+				"querystring-es3": "0.2.1",
+				"readable-stream": "2.3.5",
+				"stream-browserify": "2.0.1",
+				"stream-http": "2.8.0",
+				"string_decoder": "1.0.3",
+				"timers-browserify": "2.0.6",
+				"tty-browserify": "0.0.0",
+				"url": "0.11.0",
+				"util": "0.10.3",
+				"vm-browserify": "0.0.4"
+			}
+		},
+		"node-notifier": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+			"requires": {
+				"growly": "1.3.0",
+				"semver": "5.5.0",
+				"shellwords": "0.1.1",
+				"which": "1.3.0"
+			}
+		},
+		"normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"requires": {
+				"hosted-git-info": "2.6.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.5.0",
+				"validate-npm-package-license": "3.0.3"
+			}
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"requires": {
+				"remove-trailing-separator": "1.1.0"
+			}
+		},
+		"normalize-range": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+		},
+		"normalize-url": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+			"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+			"requires": {
+				"object-assign": "4.1.1",
+				"prepend-http": "1.0.4",
+				"query-string": "4.3.4",
+				"sort-keys": "1.1.2"
+			}
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"requires": {
+				"path-key": "2.0.1"
+			}
+		},
+		"num2fraction": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+		},
+		"nwmatcher": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
+			"integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw=="
+		},
+		"oauth-sign": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"requires": {
+				"copy-descriptor": "0.1.1",
+				"define-property": "0.2.5",
+				"kind-of": "3.2.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				}
+			}
+		},
+		"object-keys": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+		},
+		"object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"requires": {
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"requires": {
+				"define-properties": "1.1.2",
+				"es-abstract": "1.10.0"
+			}
+		},
+		"object.omit": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"requires": {
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"requires": {
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1.0.2"
+			}
+		},
+		"optimist": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"requires": {
+				"minimist": "0.0.8",
+				"wordwrap": "0.0.3"
+			}
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"requires": {
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+				}
+			}
+		},
+		"os-browserify": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
+		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+		},
+		"os-locale": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"requires": {
+				"execa": "0.7.0",
+				"lcid": "1.0.0",
+				"mem": "1.1.0"
+			}
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+		},
+		"p-limit": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+			"requires": {
+				"p-try": "1.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"requires": {
+				"p-limit": "1.2.0"
+			}
+		},
+		"p-try": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+		},
+		"pako": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
+		},
+		"parse-asn1": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+			"requires": {
+				"asn1.js": "4.10.1",
+				"browserify-aes": "1.1.1",
+				"create-hash": "1.1.3",
+				"evp_bytestokey": "1.0.3",
+				"pbkdf2": "3.0.14"
+			}
+		},
+		"parse-glob": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"requires": {
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
+			}
+		},
+		"parse-json": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"requires": {
+				"error-ex": "1.3.1"
+			}
+		},
+		"parse5": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+		},
+		"pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+		},
+		"path-browserify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
+		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+		},
+		"path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+		},
+		"path-parse": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+		},
+		"path-type": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+				}
+			}
+		},
+		"pbkdf2": {
+			"version": "3.0.14",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
+			"integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+			"requires": {
+				"create-hash": "1.1.3",
+				"create-hmac": "1.1.6",
+				"ripemd160": "2.0.1",
+				"safe-buffer": "5.1.1",
+				"sha.js": "2.4.10"
+			}
+		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+		},
+		"pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"requires": {
+				"pinkie": "2.0.4"
+			}
+		},
+		"pkg-dir": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"requires": {
+				"find-up": "2.1.0"
+			}
+		},
+		"pn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+		},
+		"posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+		},
+		"postcss": {
+			"version": "5.2.18",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+			"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+			"requires": {
+				"chalk": "1.1.3",
+				"js-base64": "2.4.3",
+				"source-map": "0.5.7",
+				"supports-color": "3.2.3"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"postcss-calc": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+			"integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
+			"requires": {
+				"postcss": "5.2.18",
+				"postcss-message-helpers": "2.0.0",
+				"reduce-css-calc": "1.3.0"
+			}
+		},
+		"postcss-colormin": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+			"integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
+			"requires": {
+				"colormin": "1.1.2",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"postcss-convert-values": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+			"integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
+			"requires": {
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"postcss-discard-comments": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+			"integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
+			"requires": {
+				"postcss": "5.2.18"
+			}
+		},
+		"postcss-discard-duplicates": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+			"integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
+			"requires": {
+				"postcss": "5.2.18"
+			}
+		},
+		"postcss-discard-empty": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+			"integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
+			"requires": {
+				"postcss": "5.2.18"
+			}
+		},
+		"postcss-discard-overridden": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+			"integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
+			"requires": {
+				"postcss": "5.2.18"
+			}
+		},
+		"postcss-discard-unused": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+			"integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
+			"requires": {
+				"postcss": "5.2.18",
+				"uniqs": "2.0.0"
+			}
+		},
+		"postcss-filter-plugins": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+			"integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
+			"requires": {
+				"postcss": "5.2.18",
+				"uniqid": "4.1.1"
+			}
+		},
+		"postcss-merge-idents": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+			"integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
+			"requires": {
+				"has": "1.0.1",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"postcss-merge-longhand": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+			"integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
+			"requires": {
+				"postcss": "5.2.18"
+			}
+		},
+		"postcss-merge-rules": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+			"integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
+			"requires": {
+				"browserslist": "1.7.7",
+				"caniuse-api": "1.6.1",
+				"postcss": "5.2.18",
+				"postcss-selector-parser": "2.2.3",
+				"vendors": "1.0.1"
+			}
+		},
+		"postcss-message-helpers": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+			"integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4="
+		},
+		"postcss-minify-font-values": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+			"integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
+			"requires": {
+				"object-assign": "4.1.1",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"postcss-minify-gradients": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+			"integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
+			"requires": {
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"postcss-minify-params": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+			"integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
+			"requires": {
+				"alphanum-sort": "1.0.2",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0",
+				"uniqs": "2.0.0"
+			}
+		},
+		"postcss-minify-selectors": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+			"integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
+			"requires": {
+				"alphanum-sort": "1.0.2",
+				"has": "1.0.1",
+				"postcss": "5.2.18",
+				"postcss-selector-parser": "2.2.3"
+			}
+		},
+		"postcss-modules-extract-imports": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
+			"integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
+			"requires": {
+				"postcss": "6.0.19"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"postcss": {
+					"version": "6.0.19",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
+					"integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+					"requires": {
+						"chalk": "2.3.2",
+						"source-map": "0.6.1",
+						"supports-color": "5.3.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-modules-local-by-default": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+			"integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+			"requires": {
+				"css-selector-tokenizer": "0.7.0",
+				"postcss": "6.0.19"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"postcss": {
+					"version": "6.0.19",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
+					"integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+					"requires": {
+						"chalk": "2.3.2",
+						"source-map": "0.6.1",
+						"supports-color": "5.3.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-modules-scope": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+			"integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+			"requires": {
+				"css-selector-tokenizer": "0.7.0",
+				"postcss": "6.0.19"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"postcss": {
+					"version": "6.0.19",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
+					"integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+					"requires": {
+						"chalk": "2.3.2",
+						"source-map": "0.6.1",
+						"supports-color": "5.3.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-modules-values": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+			"integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+			"requires": {
+				"icss-replace-symbols": "1.1.0",
+				"postcss": "6.0.19"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"requires": {
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"postcss": {
+					"version": "6.0.19",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
+					"integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+					"requires": {
+						"chalk": "2.3.2",
+						"source-map": "0.6.1",
+						"supports-color": "5.3.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-normalize-charset": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+			"integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
+			"requires": {
+				"postcss": "5.2.18"
+			}
+		},
+		"postcss-normalize-url": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+			"integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
+			"requires": {
+				"is-absolute-url": "2.1.0",
+				"normalize-url": "1.9.1",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"postcss-ordered-values": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+			"integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
+			"requires": {
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"postcss-reduce-idents": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+			"integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
+			"requires": {
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"postcss-reduce-initial": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+			"integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
+			"requires": {
+				"postcss": "5.2.18"
+			}
+		},
+		"postcss-reduce-transforms": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+			"integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
+			"requires": {
+				"has": "1.0.1",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"postcss-selector-parser": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+			"requires": {
+				"flatten": "1.0.2",
+				"indexes-of": "1.0.1",
+				"uniq": "1.0.1"
+			}
+		},
+		"postcss-svgo": {
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+			"integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
+			"requires": {
+				"is-svg": "2.1.0",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0",
+				"svgo": "0.7.2"
+			}
+		},
+		"postcss-unique-selectors": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+			"integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
+			"requires": {
+				"alphanum-sort": "1.0.2",
+				"postcss": "5.2.18",
+				"uniqs": "2.0.0"
+			}
+		},
+		"postcss-value-parser": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+			"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
+		},
+		"postcss-zindex": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+			"integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
+			"requires": {
+				"has": "1.0.1",
+				"postcss": "5.2.18",
+				"uniqs": "2.0.0"
+			}
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+		},
+		"prepend-http": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+		},
+		"preserve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+		},
+		"pretty-format": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.0.tgz",
+			"integrity": "sha512-pvCxP2iODIIk9adXlo4S3GRj0BrJiil68kByAa1PrgG97c1tClh9dLMgp3Z6cHFZrclaABt0UH8PIhwHuFLqYA==",
+			"requires": {
+				"ansi-regex": "3.0.0",
+				"ansi-styles": "3.2.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				}
+			}
+		},
+		"private": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+		},
+		"process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+		},
+		"process-nextick-args": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+		},
+		"prr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+		},
+		"public-encrypt": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+			"integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+			"requires": {
+				"bn.js": "4.11.8",
+				"browserify-rsa": "4.0.1",
+				"create-hash": "1.1.3",
+				"parse-asn1": "5.1.0",
+				"randombytes": "2.0.6"
+			}
+		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+		},
+		"q": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+		},
+		"qs": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+		},
+		"query-string": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+			"requires": {
+				"object-assign": "4.1.1",
+				"strict-uri-encode": "1.1.0"
+			}
+		},
+		"querystring": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+		},
+		"querystring-es3": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
+		},
+		"randomatic": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
+		},
+		"randombytes": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"randomfill": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+			"requires": {
+				"randombytes": "2.0.6",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"read-pkg": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+			"requires": {
+				"load-json-file": "1.1.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "1.1.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+			"requires": {
+				"find-up": "1.1.2",
+				"read-pkg": "1.1.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"requires": {
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				}
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+			"requires": {
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "2.0.0",
+				"safe-buffer": "5.1.1",
+				"string_decoder": "1.0.3",
+				"util-deprecate": "1.0.2"
+			}
+		},
+		"readdirp": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"minimatch": "3.0.4",
+				"readable-stream": "2.3.5",
+				"set-immediate-shim": "1.0.1"
+			}
+		},
+		"realpath-native": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
+			"integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
+			"requires": {
+				"util.promisify": "1.0.0"
+			}
+		},
+		"reduce-css-calc": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
+			"requires": {
+				"balanced-match": "0.4.2",
+				"math-expression-evaluator": "1.2.17",
+				"reduce-function-call": "1.0.2"
+			}
+		},
+		"reduce-function-call": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
+			"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
+			"requires": {
+				"balanced-match": "0.4.2"
+			}
+		},
+		"regenerate": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+		},
+		"regenerator-runtime": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+		},
+		"regex-cache": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"requires": {
+				"is-equal-shallow": "0.1.3"
+			}
+		},
+		"regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"requires": {
+				"extend-shallow": "3.0.2",
+				"safe-regex": "1.1.0"
+			}
+		},
+		"regexpu-core": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+			"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+			"requires": {
+				"regenerate": "1.3.3",
+				"regjsgen": "0.2.0",
+				"regjsparser": "0.1.5"
+			}
+		},
+		"regjsgen": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+		},
+		"regjsparser": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"requires": {
+				"jsesc": "0.5.0"
+			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+		},
+		"repeat-element": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+		},
+		"repeating": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"requires": {
+				"is-finite": "1.0.2"
+			}
+		},
+		"request": {
+			"version": "2.83.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+			"requires": {
+				"aws-sign2": "0.7.0",
+				"aws4": "1.6.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.6",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.2",
+				"har-validator": "5.0.3",
+				"hawk": "6.0.2",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.18",
+				"oauth-sign": "0.8.2",
+				"performance-now": "2.1.0",
+				"qs": "6.5.1",
+				"safe-buffer": "5.1.1",
+				"stringstream": "0.0.5",
+				"tough-cookie": "2.3.4",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.2.1"
+			}
+		},
+		"request-promise-core": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"requires": {
+				"request-promise-core": "1.1.1",
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.3.4"
+			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+		},
+		"require-main-filename": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+		},
+		"resolve": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+		},
+		"resolve-cwd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+			"requires": {
+				"resolve-from": "3.0.0"
+			}
+		},
+		"resolve-from": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+		},
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+		},
+		"right-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+			"requires": {
+				"align-text": "0.1.4"
+			}
+		},
+		"rimraf": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"requires": {
+				"glob": "7.1.2"
+			}
+		},
+		"ripemd160": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+			"integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+			"requires": {
+				"hash-base": "2.0.2",
+				"inherits": "2.0.3"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"requires": {
+				"ret": "0.1.15"
+			}
+		},
+		"sane": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-2.4.1.tgz",
+			"integrity": "sha512-fW9svvNd81XzHDZyis9/tEY1bZikDGryy8Hi1BErPyNPYv47CdLseUN+tI5FBHWXEENRtj1SWtX/jBnggLaP0w==",
+			"requires": {
+				"anymatch": "1.3.2",
+				"exec-sh": "0.2.1",
+				"fb-watchman": "2.0.0",
+				"fsevents": "1.1.3",
+				"minimatch": "3.0.4",
+				"minimist": "1.2.0",
+				"walker": "1.0.7",
+				"watch": "0.18.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+		},
+		"schema-utils": {
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
+			"integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
+			"requires": {
+				"ajv": "6.2.1",
+				"ajv-keywords": "3.1.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.2.1.tgz",
+					"integrity": "sha1-KKarxJOiq+D7TIUHrK7bQ/pVBnE=",
+					"requires": {
+						"fast-deep-equal": "1.1.0",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.3.1"
+					}
+				}
+			}
+		},
+		"semver": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+		},
+		"set-getter": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+			"integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
+			"requires": {
+				"to-object-path": "0.3.0"
+			}
+		},
+		"set-immediate-shim": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+		},
+		"set-value": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"requires": {
+				"extend-shallow": "2.0.1",
+				"is-extendable": "0.1.1",
+				"is-plain-object": "2.0.4",
+				"split-string": "3.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				}
+			}
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+		},
+		"sha.js": {
+			"version": "2.4.10",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
+			"integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
+			"requires": {
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"requires": {
+				"shebang-regex": "1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+		},
+		"shellwords": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		},
+		"slash": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+		},
+		"snapdragon": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
+			"integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
+			"requires": {
+				"base": "0.11.2",
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"map-cache": "0.2.2",
+				"source-map": "0.5.7",
+				"source-map-resolve": "0.5.1",
+				"use": "2.0.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+				}
+			}
+		},
+		"snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"requires": {
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"snapdragon-util": "3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"sntp": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+			"requires": {
+				"hoek": "4.2.1"
+			}
+		},
+		"sort-keys": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+			"requires": {
+				"is-plain-obj": "1.1.0"
+			}
+		},
+		"source-list-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+		},
+		"source-map-resolve": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+			"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+			"requires": {
+				"atob": "2.0.3",
+				"decode-uri-component": "0.2.0",
+				"resolve-url": "0.2.1",
+				"source-map-url": "0.4.0",
+				"urix": "0.1.0"
+			}
+		},
+		"source-map-support": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
+			"integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
+			"requires": {
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"source-map-url": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+		},
+		"spdx-correct": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+			"requires": {
+				"spdx-expression-parse": "3.0.0",
+				"spdx-license-ids": "3.0.0"
+			}
+		},
+		"spdx-exceptions": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+		},
+		"spdx-expression-parse": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"requires": {
+				"spdx-exceptions": "2.1.0",
+				"spdx-license-ids": "3.0.0"
+			}
+		},
+		"spdx-license-ids": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"requires": {
+				"extend-shallow": "3.0.2"
+			}
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"sshpk": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"requires": {
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"stack-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
+			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
+		},
+		"static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"requires": {
+				"define-property": "0.2.5",
+				"object-copy": "0.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+				}
+			}
+		},
+		"stats-webpack-plugin": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/stats-webpack-plugin/-/stats-webpack-plugin-0.6.2.tgz",
+			"integrity": "sha1-LFlJtTHgf4eojm6k3PrFOqjHWis=",
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+		},
+		"stream-browserify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5"
+			}
+		},
+		"stream-http": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz",
+			"integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
+			"requires": {
+				"builtin-status-codes": "3.0.0",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5",
+				"to-arraybuffer": "1.0.1",
+				"xtend": "4.0.1"
+			}
+		},
+		"strict-uri-encode": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+		},
+		"string-length": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+			"requires": {
+				"astral-regex": "1.0.0",
+				"strip-ansi": "4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"requires": {
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"stringstream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+		},
+		"strip-ansi": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"strip-bom": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+			"requires": {
+				"is-utf8": "0.2.1"
+			}
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+		},
+		"style-loader": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.20.2.tgz",
+			"integrity": "sha512-FrLMGaOLVhS5pvoez3eJyc0ktchT1inEZziBSjBq1hHQBK3GFkF57Qd825DcrUhjaAWQk70MKrIl5bfjadR/Dg==",
+			"requires": {
+				"loader-utils": "1.1.0",
+				"schema-utils": "0.4.5"
+			}
+		},
+		"supports-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+		},
+		"svgo": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+			"integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
+			"requires": {
+				"coa": "1.0.4",
+				"colors": "1.1.2",
+				"csso": "2.3.2",
+				"js-yaml": "3.7.0",
+				"mkdirp": "0.5.1",
+				"sax": "1.2.4",
+				"whet.extend": "0.9.9"
+			}
+		},
+		"symbol-tree": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+		},
+		"tapable": {
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
+			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
+		},
+		"test-exclude": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.0.tgz",
+			"integrity": "sha512-8hMFzjxbPv6xSlwGhXSvOMJ/vTy3bkng+2pxmf6E1z6VF7I9nIyNfvHtaw+NBPgvz647gADBbMSbwLfZYppT/w==",
+			"requires": {
+				"arrify": "1.0.1",
+				"micromatch": "2.3.11",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"require-main-filename": "1.0.1"
+			}
+		},
+		"throat": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
+		},
+		"timers-browserify": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
+			"integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
+			"requires": {
+				"setimmediate": "1.0.5"
+			}
+		},
+		"tmpl": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+		},
+		"to-arraybuffer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
+		},
+		"to-fast-properties": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"requires": {
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"regex-not": "1.0.2",
+				"safe-regex": "1.1.0"
+			}
+		},
+		"to-regex-range": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"requires": {
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				}
+			}
+		},
+		"tough-cookie": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+			"requires": {
+				"punycode": "1.4.1"
+			}
+		},
+		"tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"requires": {
+				"punycode": "2.1.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+				}
+			}
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+		},
+		"tty-browserify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"optional": true
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"requires": {
+				"prelude-ls": "1.1.2"
+			}
+		},
+		"uglify-js": {
+			"version": "2.8.29",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+			"requires": {
+				"source-map": "0.5.7",
+				"uglify-to-browserify": "1.0.2",
+				"yargs": "3.10.0"
+			},
+			"dependencies": {
+				"yargs": {
+					"version": "3.10.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+					"requires": {
+						"camelcase": "1.2.1",
+						"cliui": "2.1.0",
+						"decamelize": "1.2.0",
+						"window-size": "0.1.0"
+					}
+				}
+			}
+		},
+		"uglify-to-browserify": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"optional": true
+		},
+		"uglifyjs-webpack-plugin": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
+			"integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
+			"requires": {
+				"source-map": "0.5.7",
+				"uglify-js": "2.8.29",
+				"webpack-sources": "1.1.0"
+			}
+		},
+		"union-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"requires": {
+				"arr-union": "3.1.0",
+				"get-value": "2.0.6",
+				"is-extendable": "0.1.1",
+				"set-value": "0.4.3"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				},
+				"set-value": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"to-object-path": "0.3.0"
+					}
+				}
+			}
+		},
+		"uniq": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+		},
+		"uniqid": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
+			"integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
+			"requires": {
+				"macaddress": "0.2.8"
+			}
+		},
+		"uniqs": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
+		},
+		"unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"requires": {
+				"has-value": "0.3.1",
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"has-value": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"requires": {
+						"get-value": "2.0.6",
+						"has-values": "0.1.4",
+						"isobject": "2.1.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"has-values": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"upath": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
+			"integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw=="
+		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+		},
+		"url": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+			"requires": {
+				"punycode": "1.3.2",
+				"querystring": "0.2.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+				}
+			}
+		},
+		"use": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
+			"integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
+			"requires": {
+				"define-property": "0.2.5",
+				"isobject": "3.0.1",
+				"lazy-cache": "2.0.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+				},
+				"lazy-cache": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+					"integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+					"requires": {
+						"set-getter": "0.1.0"
+					}
+				}
+			}
+		},
+		"util": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+			"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+			"requires": {
+				"inherits": "2.0.1"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+				}
+			}
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"util.promisify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"requires": {
+				"define-properties": "1.1.2",
+				"object.getownpropertydescriptors": "2.0.3"
+			}
+		},
+		"uuid": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+			"requires": {
+				"spdx-correct": "3.0.0",
+				"spdx-expression-parse": "3.0.0"
+			}
+		},
+		"vendors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
+			"integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI="
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "1.3.0"
+			}
+		},
+		"vm-browserify": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+			"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+			"requires": {
+				"indexof": "0.0.1"
+			}
+		},
+		"w3c-hr-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"requires": {
+				"browser-process-hrtime": "0.1.2"
+			}
+		},
+		"walker": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+			"requires": {
+				"makeerror": "1.0.11"
+			}
+		},
+		"watch": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
+			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+			"requires": {
+				"exec-sh": "0.2.1",
+				"minimist": "1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
+		"watchpack": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.5.0.tgz",
+			"integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
+			"requires": {
+				"chokidar": "2.0.2",
+				"graceful-fs": "4.1.11",
+				"neo-async": "2.5.0"
+			}
+		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+		},
+		"webpack": {
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.11.0.tgz",
+			"integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
+			"requires": {
+				"acorn": "5.5.1",
+				"acorn-dynamic-import": "2.0.2",
+				"ajv": "6.2.1",
+				"ajv-keywords": "3.1.0",
+				"async": "2.6.0",
+				"enhanced-resolve": "3.4.1",
+				"escope": "3.6.0",
+				"interpret": "1.1.0",
+				"json-loader": "0.5.7",
+				"json5": "0.5.1",
+				"loader-runner": "2.3.0",
+				"loader-utils": "1.1.0",
+				"memory-fs": "0.4.1",
+				"mkdirp": "0.5.1",
+				"node-libs-browser": "2.1.0",
+				"source-map": "0.5.7",
+				"supports-color": "4.5.0",
+				"tapable": "0.2.8",
+				"uglifyjs-webpack-plugin": "0.4.6",
+				"watchpack": "1.5.0",
+				"webpack-sources": "1.1.0",
+				"yargs": "8.0.2"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.2.1.tgz",
+					"integrity": "sha1-KKarxJOiq+D7TIUHrK7bQ/pVBnE=",
+					"requires": {
+						"fast-deep-equal": "1.1.0",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.3.1"
+					}
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							}
+						}
+					}
+				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"strip-bom": "3.0.0"
+					}
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"requires": {
+						"pify": "2.3.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"requires": {
+						"load-json-file": "2.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"requires": {
+						"find-up": "2.1.0",
+						"read-pkg": "2.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+				},
+				"supports-color": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"requires": {
+						"has-flag": "2.0.0"
+					}
+				},
+				"yargs": {
+					"version": "8.0.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+					"requires": {
+						"camelcase": "4.1.0",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"read-pkg-up": "2.0.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "7.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+					"requires": {
+						"camelcase": "4.1.0"
+					}
+				}
+			}
+		},
+		"webpack-sources": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+			"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+			"requires": {
+				"source-list-map": "2.0.0",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"whatwg-encoding": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+			"requires": {
+				"iconv-lite": "0.4.19"
+			}
+		},
+		"whatwg-url": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+			"integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+			"requires": {
+				"lodash.sortby": "4.7.0",
+				"tr46": "1.0.1",
+				"webidl-conversions": "4.0.2"
+			}
+		},
+		"whet.extend": {
+			"version": "0.9.9",
+			"resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+			"integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE="
+		},
+		"which": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"requires": {
+				"isexe": "2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+		},
+		"window-size": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+		},
+		"wordwrap": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+		},
+		"wrap-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"requires": {
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				}
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"write-file-atomic": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"imurmurhash": "0.1.4",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"ws": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+			"requires": {
+				"async-limiter": "1.0.0",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"xml-name-validator": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+		},
+		"y18n": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+		},
+		"yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+		},
+		"yargs": {
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+			"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+			"requires": {
+				"cliui": "4.0.0",
+				"decamelize": "1.2.0",
+				"find-up": "2.1.0",
+				"get-caller-file": "1.0.2",
+				"os-locale": "2.1.0",
+				"require-directory": "2.1.1",
+				"require-main-filename": "1.0.1",
+				"set-blocking": "2.0.0",
+				"string-width": "2.1.1",
+				"which-module": "2.0.0",
+				"y18n": "3.2.1",
+				"yargs-parser": "8.1.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"cliui": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+					"requires": {
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
+		"yargs-parser": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+			"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+			"requires": {
+				"camelcase": "4.1.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				}
+			}
+		}
+	}
+}

--- a/__tests__/setups/v3-stats/package.json
+++ b/__tests__/setups/v3-stats/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "v3-stats",
+  "version": "0.0.1",
+  "description": "Test webpack v3 with a StatsPlugin set-up with SMP",
+  "scripts": {
+    "prepare": "cp -r ../../common/* .",
+    "test": "jest ./smp.test.js",
+    "cleanup": "rm -rf dist"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=6.0.0"
+  },
+  "devDependencies": {
+    "babel-loader": "^7.1.1",
+    "css-loader": "^0.28.10",
+    "jest": "^22.3.0",
+    "style-loader": "^0.20.2",
+    "webpack": "3.x.x"
+  },
+  "dependencies": {
+    "stats-webpack-plugin": "^0.6.2"
+  }
+}

--- a/__tests__/setups/v3-stats/webpack.config.js
+++ b/__tests__/setups/v3-stats/webpack.config.js
@@ -1,0 +1,28 @@
+const webpack = require("webpack");
+const StatsPlugin = require("stats-webpack-plugin");
+
+module.exports = {
+  entry: {
+    bundle: ["./app.js"],
+  },
+  output: {
+    path: __dirname + "/dist"
+  },
+  plugins: [
+    new StatsPlugin("stats.json"),
+    // StatsPlugin needs to be placed _before_ DefinePlugin to repro the issue
+    new webpack.DefinePlugin({ FOO: "'BAR'" }),
+  ],
+  module: {
+    rules: [
+      {
+        test: /\.js?$/,
+        use: "babel-loader"
+      },
+      {
+        test: /\.css$/,
+        use: ["style-loader", "css-loader"]
+      }
+    ]
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "speed-measure-webpack-plugin",
-	"version": "1.1.1",
+	"version": "1.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speed-measure-webpack-plugin",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Measure + analyse the speed of your webpack loaders and plugins",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This should fix the issue described in https://github.com/stephencookdev/speed-measure-webpack-plugin/issues/28

Basically the way we were tagging elements in order to break infinite-loops was causing any code running through object keys to get upset (e.g. `Object.keys(compilation.assets).forEach(asset => compilation.assets[asset].size())`, since one of the `asset` keys is just `_smpWrapped` mapping to `true`)

This change uses a locally referenced array instead