### PR TITLE
Fix memory leak in WrappedPlugin

### DIFF
--- a/WrappedPlugin/index.js
+++ b/WrappedPlugin/index.js
@@ -243,6 +243,11 @@ const wrap = (orig, pluginName, smp, addEndEvent) => {
   return wrappedReturn;
 };
 
+module.exports.clear = () => {
+  wrappedObjs.length = 0;
+  wrappedHooks.length = 0;
+};
+
 module.exports.WrappedPlugin = class WrappedPlugin {
   constructor(plugin, pluginName, smp) {
     this._smp_plugin = plugin;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const fs = require("fs");
 const chalk = require("chalk");
-const { WrappedPlugin } = require("./WrappedPlugin");
+const { WrappedPlugin, clear } = require("./WrappedPlugin");
 const {
   getModuleName,
   getLoaderNames,
@@ -120,6 +120,7 @@ module.exports = class SpeedMeasurePlugin {
       this.addTimeEvent("misc", "compile", "start", { watch: false });
     });
     tap(compiler, "done", () => {
+      clear();
       this.addTimeEvent("misc", "compile", "end", { fillLast: true });
 
       const outputToFile = typeof this.options.outputTarget === "string";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speed-measure-webpack-plugin",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Measure + analyse the speed of your webpack loaders and plugins",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This should address the memory leak raised in https://github.com/stephencookdev/speed-measure-webpack-plugin/issues/35