### PR TITLE
fix: correct the regexp for parsing loader name to support scoped package name

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -50,7 +50,12 @@ module.exports.getLoaderNames = loaders =>
   loaders && loaders.length
     ? loaders
         .map(l => l.loader || l)
-        .map(l => l.replace(/^.*\/node_modules\/([^\/]+).*$/, (_, m) => m))
+        .map(l =>
+          l.replace(
+            /^.*\/node_modules\/(@[a-z0-9][\w-.]+\/[a-z0-9][\w-.]*|[^\/]+).*$/,
+            (_, m) => m
+          )
+        )
         .filter(l => !l.includes("speed-measure-webpack-plugin"))
     : ["modules with no loaders"];
 


### PR DESCRIPTION
For package name `@scope/name`, currently the output is `@scope`.
This PR fix improve the regexp to support scoped package name.

Fix #73
