### PR TITLE
fix: use fs sync method to write files

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,14 +140,12 @@ module.exports = class SpeedMeasurePlugin {
       chalk.enabled = true;
       if (outputToFile) {
         const writeMethod = fs.existsSync(this.options.outputTarget)
-          ? fs.appendFile
-          : fs.writeFile;
-        writeMethod(this.options.outputTarget, output + "\n", err => {
-          if (err) throw err;
-          console.log(
-            smpTag() + "Outputted timing info to " + this.options.outputTarget
-          );
-        });
+          ? fs.appendFileSync
+          : fs.writeFileSync;
+        writeMethod(this.options.outputTarget, output + "\n");
+        console.log(
+          smpTag() + "Outputted timing info to " + this.options.outputTarget
+        );
       } else {
         const outputFunc = this.options.outputTarget || console.log;
         outputFunc(output);


### PR DESCRIPTION
In certain cases the stats are not written, this seems to be because the process is being terminated before it finish to write. The reason being is using a sync version of tap.

To get around this, the sync method of fs should be used to allow the creation of files.

Related to: https://github.com/angular/angular-cli/issues/12763