### PR TITLE
Add ignore plugins option

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const NS = path.dirname(fs.realpathSync(__filename));
 module.exports = class SpeedMeasurePlugin {
   constructor(options) {
     this.options = options || {};
-
+    this.ignorePlugins = this.options.ignorePlugins || [];
     this.timeEventData = {};
     this.smpPluginAdded = false;
 
@@ -45,7 +45,9 @@ module.exports = class SpeedMeasurePlugin {
         ) ||
         (plugin.constructor && plugin.constructor.name) ||
         "(unable to deduce plugin name)";
-      return new WrappedPlugin(plugin, pluginName, this);
+      return this.ignorePlugins.includes(pluginName)
+        ? plugin
+        : new WrappedPlugin(plugin, pluginName, this);
     });
 
     if (config.optimization && config.optimization.minimizer) {


### PR DESCRIPTION
Some plugins have issues with this speed measure.

This enables the ability to ignore wrapping of matching plugins