### PR TITLE
Fix/windows loader names

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -7,8 +7,8 @@ let id = 0;
 const NS = path.dirname(fs.realpathSync(__filename));
 
 const getLoaderName = path => {
-  const nodeModuleName = /\/node_modules\/([^\/]+)/.exec(path);
-  return (nodeModuleName && nodeModuleName[1]) || "";
+  const nodeModuleName = /[\\/]node_modules[\\/](@[a-z0-9][\w-.]+[\\/][a-z0-9][\w-.]*|[^\\/]+)/.exec(path);
+  return ((nodeModuleName && nodeModuleName[1]) || "").replace("\\", "/");
 };
 
 module.exports.pitch = function() {

--- a/utils.js
+++ b/utils.js
@@ -52,9 +52,9 @@ module.exports.getLoaderNames = loaders =>
         .map(l => l.loader || l)
         .map(l =>
           l.replace(
-            /^.*\/node_modules\/(@[a-z0-9][\w-.]+\/[a-z0-9][\w-.]*|[^\/]+).*$/,
+            /^.*[\\/]node_modules[\\/](@[a-z0-9][\w-.]+[\\/][a-z0-9][\w-.]*|[^\\/]+).*$/
             (_, m) => m
-          )
+          ).replace("\\", "/")
         )
         .filter(l => !l.includes("speed-measure-webpack-plugin"))
     : ["modules with no loaders"];


### PR DESCRIPTION
Addresses #84 

- Updates loader name extraction regexes to incorporate both forward and backward slashes for *nix and Windows file-system path conventions.
- For consistent presentation normalizes back-slashes remaining in the loader name when scoped packages are extracted from Windows file-system paths, to forward slashes.

Also; consistently applies the fix for scoped packages, which was missing from one of the regexes.