### PR TITLE
Add FAQ on readme about the different outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,16 @@ This flag is _experimental_. Some loaders will have inaccurate results:
 
 We will find solutions to these issues before removing the _(experimental)_ flag on this option.
 
+## FAQ
+
+### What does general output time mean?
+
+This tends to be generally down to webpack reading in from the file-system, but it's hard to say - it'll be very repo specific!
+
+### What does modules without loaders mean?
+
+It basically just means vanilla JS files, which webpack can handle out of the box.
+
 ## Contributing
 
 Contributors are welcome! 😊


### PR DESCRIPTION
I found myself having the same questions as in this [issue](https://github.com/stephencookdev/speed-measure-webpack-plugin/issues/59).
Seems there was no answer from the issue opener so I'd like to have this in the readme.

The answer for the "general output time" is still pretty unclear for me and I'd love more feedback on this matter from you @stephencookdev 

Cheers,