### PR TITLE
fix compilation.compiler not wrapped in callback arguments

### DIFF
--- a/WrappedPlugin/index.js
+++ b/WrappedPlugin/index.js
@@ -164,12 +164,16 @@ const construcNamesToWrap = [
 ];
 
 const wrappedObjs = [];
-const wrap = (orig, pluginName, smp, addEndEvent) => {
-  if (!orig) return orig;
+const findWrappedObj = (orig, pluginName) => {
   const prevWrapped = wrappedObjs.find(
     w => w.pluginName === pluginName && (w.orig === orig || w.wrapped === orig)
   );
   if (prevWrapped) return prevWrapped.wrapped;
+};
+const wrap = (orig, pluginName, smp, addEndEvent) => {
+  if (!orig) return orig;
+  const prevWrapped = findWrappedObj(orig, pluginName);
+  if (prevWrapped) return prevWrapped;
 
   const getOrigConstrucName = target =>
     target && target.constructor && target.constructor.name;
@@ -216,6 +220,13 @@ const wrap = (orig, pluginName, smp, addEndEvent) => {
             smp,
             getOrigConstrucName(target)
           );
+
+        if (shouldWrap && property === "compiler") {
+          const prevWrapped = findWrappedObj(raw, pluginName);
+          if (prevWrapped) {
+            return prevWrapped;
+          }
+        }
 
         if (typeof raw === "function") {
           const ret = raw.bind(proxy);


### PR DESCRIPTION
Hi @stephencookdev 

First thanks a lot for this fantastic plugin.!I was searching for a way to measure the performance of webpack building, while the built-in ProfilingPlugin is not that straightforward to measure the timing for each plugin & loader, this plugin shows up and I think it is really brilliant.

One thing though, is that when I integrate it into my project I found that it cannot work with [html-webpack-plugin@next](https://github.com/jantimon/html-webpack-plugin/). It works with html-webpack-plugin v3 though, but I decided to dig in and take a look. (because I'm also using other plugins that require html-webpack-plugin@next)

So if I do not understand this plugin wrong, it's using proxy and reflect to intercept webpack's tabable plugin system. Object such as `compiler` and `compilation`, along with their methods such as `tap`, `tapAsync` and hooks are proxyed, which I think is really clever. Even argument in hook's callback is proxyed, such as argument `compilation`.

The problem lies in how html-webpack-plugin works,  https://github.com/jantimon/html-webpack-plugin/blob/master/lib/compiler.js#L203-L218  on `apply` it will save compiler into a cache weakmap (with the key as the compiler, which is already proxyed). However, in it's `thisCompilation` hook https://github.com/jantimon/html-webpack-plugin/blob/master/index.js#L134-L136 , it will search that cache again with the key `compilation.compiler`. ⬅️**This is where the problem is from.** **In SMP,  `compilation.compiler` in hook callback will return the original compiler object, not the proxyed one.** I believe this is because in webpack's code, in it's constructor compilation will have a reference of compiler on being created. https://github.com/webpack/webpack/blob/master/lib/Compiler.js#L852-L854 Therefore, if any plugin is accessing `compilation.compiler` in hooks callback, it will not get the proxied one.

Luckily I found that in your code, you have a `wrappedObj` which contains the already proxied objects. So it's possible that we check in the wrappedObjs before returning the raw object for `compilation.compiler`.

I extracted the `prevWrapped` logic out into a method called `findWrappedObj`, and reuse it in the proxy handler for property retrieving on argument.

In the issues list I also found that there're some plugins won't work with SMP. I'm not sure if this could help with them. But for html-webpack-plugin@next, you could find how to reproduce it here from this project: https://github.com/NdYAG/smp-html

|In this project, before using the patch: |after this patch:|
|---|---|
|![image](https://user-images.githubusercontent.com/1396511/77066748-a8191280-6a1e-11ea-91c7-76ba8249dd12.png)|![image](https://user-images.githubusercontent.com/1396511/77067576-21653500-6a20-11ea-9df9-cd5f028483d6.png)|

It would be really great if you could take a look of it, if there're any questions please comment and metion me. I love this plugin and hope that it could work with as many other plugins as possible.
