### PR TITLE
fix: allow rules with loader+options combination (useEntry)

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -97,6 +97,10 @@ const prependLoader = rules => {
 
   if (rules.loader) {
     rules.use = [rules.loader];
+    if (rules.options) {
+      rules.use[0] = { loader: rules.loader, options: rules.options };
+      delete rules.options;
+    }
     delete rules.loader;
   }
 

--- a/utils.test.js
+++ b/utils.test.js
@@ -27,6 +27,23 @@ describe("prependLoader", () => {
     },
 
     {
+      name: "single loader with options",
+
+      from: {
+        test: /\.jsx?$/,
+        loader: "babel-loader",
+        options: {},
+      },
+      to: {
+        test: /\.jsx?$/,
+        use: [
+          "speed-measure-webpack-plugin/loader",
+          { loader: "babel-loader", options: {} },
+        ],
+      },
+    },
+
+    {
       name: "single complex use",
 
       from: {


### PR DESCRIPTION
Sometimes loaders can have only `loader` and `options` property which breaks in the current setup because the `prependLoader` function will only take the `loader` and put it as a string into the `rules.use` array.
This PR addresses this issue and will add an object with `loader` and `options` to the `use` array if `options` is present.

See also [`useEntry`](https://webpack.js.org/configuration/module/#useentry) in webpack docs.